### PR TITLE
Adding a few more keywords and such

### DIFF
--- a/syntax/riscv.vim
+++ b/syntax/riscv.vim
@@ -59,47 +59,50 @@ syntax match   riscvCSRegister /\<tdata[1-3]\>/
 syntax keyword riscvCSRegister dcsr dpc dscratch
 
 " Assembler directives
-syntax match riscvDirective /\.align/
-syntax match riscvDirective /\.file/
-syntax match riscvDirective /\.globl/
-syntax match riscvDirective /\.local/
-syntax match riscvDirective /\.comm/
-syntax match riscvDirective /\.common/
-syntax match riscvDirective /\.ident/
-syntax match riscvDirective /\.section/
-syntax match riscvDirective /\.size/
-syntax match riscvDirective /\.text/
-syntax match riscvDirective /\.data/
-syntax match riscvDirective /\.rodata/
-syntax match riscvDirective /\.bss/
-syntax match riscvDirective /\.string/
-syntax match riscvDirective /\.asciz/
-syntax match riscvDirective /\.equ/
-syntax match riscvDirective /\.macro/
-syntax match riscvDirective /\.endm/
-syntax match riscvDirective /\.type/
-syntax match riscvDirective /\.option/
-syntax match riscvDirective /\.byte/
-syntax match riscvDirective /\.2byte/
-syntax match riscvDirective /\.half/
-syntax match riscvDirective /\.short/
-syntax match riscvDirective /\.4byte/
-syntax match riscvDirective /\.word/
-syntax match riscvDirective /\.long/
-syntax match riscvDirective /\.8byte/
-syntax match riscvDirective /\.dword/
-syntax match riscvDirective /\.quad/
-syntax match riscvDirective /\.skip/
-syntax match riscvDirective /\.dtprelword/
-syntax match riscvDirective /\.dtpreldword/
-syntax match riscvDirective /\.sleb128/
-syntax match riscvDirective /\.uleb128/
-syntax match riscvDirective /\.p2align/
-syntax match riscvDirective /\.balign/
-syntax match riscvDirective /\.zero/
-syntax match riscvDirective /\.global/
-syntax match riscvDirective /\.float/
-syntax match riscvDirective /\.double/
+syntax match riscvDirective "\<\.align\>"
+syntax match riscvDirective "\<\.ascii\>"
+syntax match riscvDirective "\<\.file\>"
+syntax match riscvDirective "\<\.globl\>"
+syntax match riscvDirective "\<\.local\>"
+syntax match riscvDirective "\<\.comm\>"
+syntax match riscvDirective "\<\.common\>"
+syntax match riscvDirective "\<\.ident\>"
+syntax match riscvDirective "\<\.section\>"
+syntax match riscvDirective "\<\.size\>"
+syntax match riscvDirective "\<\.text\>"
+syntax match riscvDirective "\<\.data\>"
+syntax match riscvDirective "\<\.rodata\>"
+syntax match riscvDirective "\<\.bss\>"
+syntax match riscvDirective "\<\.string\>"
+syntax match riscvDirective "\<\.asciz\>"
+syntax match riscvDirective "\<\.equ\>"
+syntax match riscvDirective "\<\.macro\>"
+syntax match riscvDirective "\<\.endm\>"
+syntax match riscvDirective "\<\.type\>"
+syntax match riscvDirective "\<\.option\>"
+syntax match riscvDirective "\<\.byte\>"
+syntax match riscvDirective "\<\.2byte\>"
+syntax match riscvDirective "\<\.half\>"
+syntax match riscvDirective "\<\.short\>"
+syntax match riscvDirective "\<\.4byte\>"
+syntax match riscvDirective "\<\.word\>"
+syntax match riscvDirective "\<\.long\>"
+syntax match riscvDirective "\<\.8byte\>"
+syntax match riscvDirective "\<\.dword\>"
+syntax match riscvDirective "\<\.quad\>"
+syntax match riscvDirective "\<\.skip\>"
+syntax match riscvDirective "\<\.dtprelword\>"
+syntax match riscvDirective "\<\.dtpreldword\>"
+syntax match riscvDirective "\<\.sleb128\>"
+syntax match riscvDirective "\<\.uleb128\>"
+syntax match riscvDirective "\<\.p2align\>"
+syntax match riscvDirective "\<\.balign\>"
+syntax match riscvDirective "\<\.zero\>"
+syntax match riscvDirective "\<\.global\>"
+syntax match riscvDirective "\<\.float\>"
+syntax match riscvDirective "\<\.double\>"
+syntax match riscvDirective "\<\.set\>"
+syntax match riscvDirective "\<\.attribute\>"
 
 " Instructions
 " loads
@@ -120,7 +123,7 @@ syntax keyword riscvInstruction beq bne blt bge bltu bgeu
 syntax keyword riscvInstruction jal jalr
 " synch
 syntax keyword riscvInstruction fence
-syntax match   riscvInstruction "fence\.i"
+syntax match   riscvInstruction "\<fence\.i\>"
 " system call
 syntax keyword riscvInstruction scall sbreak
 " counters
@@ -134,7 +137,7 @@ syntax keyword riscvInstruction mrts mrth hrts mret
 " interrupt
 syntax keyword riscvInstruction wfi
 " mmu
-syntax match   riscvInstruction "sfence\.vm"
+syntax match   riscvInstruction "\<sfence\.vm\>"
 
 " M extension
 " multiply
@@ -143,165 +146,168 @@ syntax keyword riscvInstruction mul mulh mulhsu mulhu
 syntax keyword riscvInstruction div divu rem remu
 
 " A extension
-syntax match   riscvInstruction "lr\.w"
-syntax match   riscvInstruction "sc\.w"
-syntax match   riscvInstruction "amoswap\.w"
-syntax match   riscvInstruction "amoadd\.w"
-syntax match   riscvInstruction "amoxor\.w"
-syntax match   riscvInstruction "amoand\.w"
-syntax match   riscvInstruction "amoor\.w"
-syntax match   riscvInstruction "amomin\.w"
-syntax match   riscvInstruction "amomax\.w"
-syntax match   riscvInstruction "amominu\.w"
-syntax match   riscvInstruction "amomaxu\.w"
+syntax match   riscvInstruction "\<lr\.w\>"
+syntax match   riscvInstruction "\<sc\.w\>"
+syntax match   riscvInstruction "\<amoswap\.w\>"
+syntax match   riscvInstruction "\<amoadd\.w\>"
+syntax match   riscvInstruction "\<amoxor\.w\>"
+syntax match   riscvInstruction "\<amoand\.w\>"
+syntax match   riscvInstruction "\<amoor\.w\>"
+syntax match   riscvInstruction "\<amomin\.w\>"
+syntax match   riscvInstruction "\<amomax\.w\>"
+syntax match   riscvInstruction "\<amominu\.w\>"
+syntax match   riscvInstruction "\<amomaxu\.w\>"
 
 " C extension
-syntax match   riscvInstruction "c\.addi4spn"
-syntax match   riscvInstruction "c\.fld"
-syntax match   riscvInstruction "c\.lq"
-syntax match   riscvInstruction "c\.lw"
-syntax match   riscvInstruction "c\.flw"
-syntax match   riscvInstruction "c\.ld"
-syntax match   riscvInstruction "c\.fsd"
-syntax match   riscvInstruction "c\.sq"
-syntax match   riscvInstruction "c\.sw"
-syntax match   riscvInstruction "c\.fsw"
-syntax match   riscvInstruction "c\.sd"
-syntax match   riscvInstruction "c\.nop"
-syntax match   riscvInstruction "c\.addi"
-syntax match   riscvInstruction "c\.jal"
-syntax match   riscvInstruction "c\.addiw"
-syntax match   riscvInstruction "c\.li"
-syntax match   riscvInstruction "c\.addi16sp"
-syntax match   riscvInstruction "c\.lui"
-syntax match   riscvInstruction "c\.srli"
-syntax match   riscvInstruction "c\.srli64"
-syntax match   riscvInstruction "c\.srai"
-syntax match   riscvInstruction "c\.srai64"
-syntax match   riscvInstruction "c\.andi"
-syntax match   riscvInstruction "c\.sub"
-syntax match   riscvInstruction "c\.xor"
-syntax match   riscvInstruction "c\.or"
-syntax match   riscvInstruction "c\.and"
-syntax match   riscvInstruction "c\.subw"
-syntax match   riscvInstruction "c\.addw"
-syntax match   riscvInstruction "c\.j"
-syntax match   riscvInstruction "c\.beqz"
-syntax match   riscvInstruction "c\.bnez"
-syntax match   riscvInstruction "c\.slli"
-syntax match   riscvInstruction "c\.slli64"
-syntax match   riscvInstruction "c\.fldsp"
-syntax match   riscvInstruction "c\.lqsp"
-syntax match   riscvInstruction "c\.lwsp"
-syntax match   riscvInstruction "c\.flwsp"
-syntax match   riscvInstruction "c\.ldsp"
-syntax match   riscvInstruction "c\.jr"
-syntax match   riscvInstruction "c\.mv"
-syntax match   riscvInstruction "c\.ebreak"
-syntax match   riscvInstruction "c\.jalr"
-syntax match   riscvInstruction "c\.add"
-syntax match   riscvInstruction "c\.fsdsp"
-syntax match   riscvInstruction "c\.sqsp"
-syntax match   riscvInstruction "c\.swsp"
-syntax match   riscvInstruction "c\.fswsp"
-syntax match   riscvInstruction "c\.sdsp"
+syntax match   riscvInstruction "\<c\.add\>"
+syntax match   riscvInstruction "\<c\.addi\>"
+syntax match   riscvInstruction "\<c\.addi4spn\>"
+syntax match   riscvInstruction "\<c\.addiw\>"
+syntax match   riscvInstruction "\<c\.addi16sp\>"
+syntax match   riscvInstruction "\<c\.fld\>"
+syntax match   riscvInstruction "\<c\.lq\>"
+syntax match   riscvInstruction "\<c\.lw\>"
+syntax match   riscvInstruction "\<c\.flw\>"
+syntax match   riscvInstruction "\<c\.ld\>"
+syntax match   riscvInstruction "\<c\.fsd\>"
+syntax match   riscvInstruction "\<c\.sq\>"
+syntax match   riscvInstruction "\<c\.sw\>"
+syntax match   riscvInstruction "\<c\.fsw\>"
+syntax match   riscvInstruction "\<c\.sd\>"
+syntax match   riscvInstruction "\<c\.nop\>"
+syntax match   riscvInstruction "\<c\.jal\>"
+syntax match   riscvInstruction "\<c\.li\>"
+syntax match   riscvInstruction "\<c\.lui\>"
+syntax match   riscvInstruction "\<c\.srli\>"
+syntax match   riscvInstruction "\<c\.srli64\>"
+syntax match   riscvInstruction "\<c\.srai\>"
+syntax match   riscvInstruction "\<c\.srai64\>"
+syntax match   riscvInstruction "\<c\.andi\>"
+syntax match   riscvInstruction "\<c\.sub\>"
+syntax match   riscvInstruction "\<c\.xor\>"
+syntax match   riscvInstruction "\<c\.or\>"
+syntax match   riscvInstruction "\<c\.and\>"
+syntax match   riscvInstruction "\<c\.subw\>"
+syntax match   riscvInstruction "\<c\.addw\>"
+syntax match   riscvInstruction "\<c\.j\>"
+syntax match   riscvInstruction "\<c\.beqz\>"
+syntax match   riscvInstruction "\<c\.bnez\>"
+syntax match   riscvInstruction "\<c\.slli\>"
+syntax match   riscvInstruction "\<c\.slli64\>"
+syntax match   riscvInstruction "\<c\.fldsp\>"
+syntax match   riscvInstruction "\<c\.lqsp\>"
+syntax match   riscvInstruction "\<c\.lwsp\>"
+syntax match   riscvInstruction "\<c\.flwsp\>"
+syntax match   riscvInstruction "\<c\.ldsp\>"
+syntax match   riscvInstruction "\<c\.jr\>"
+syntax match   riscvInstruction "\<c\.mv\>"
+syntax match   riscvInstruction "\<c\.ebreak\>"
+syntax match   riscvInstruction "\<c\.jalr\>"
+syntax match   riscvInstruction "\<c\.fsdsp\>"
+syntax match   riscvInstruction "\<c\.sqsp\>"
+syntax match   riscvInstruction "\<c\.swsp\>"
+syntax match   riscvInstruction "\<c\.fswsp\>"
+syntax match   riscvInstruction "\<c\.sdsp\>"
 
 " F extension
 syntax keyword riscvInstruction flw fsw
-syntax match   riscvInstruction "fmadd\.s"
-syntax match   riscvInstruction "fmsub\.s"
-syntax match   riscvInstruction "fnmsub\.s"
-syntax match   riscvInstruction "fnmadd\.s"
-syntax match   riscvInstruction "fadd\.s"
-syntax match   riscvInstruction "fsub\.s"
-syntax match   riscvInstruction "fmul\.s"
-syntax match   riscvInstruction "fdiv\.s"
-syntax match   riscvInstruction "fsqrt\.s"
-syntax match   riscvInstruction "fsgnj\.s"
-syntax match   riscvInstruction "fsgnjn\.s"
-syntax match   riscvInstruction "fsgnjx\.s"
-syntax match   riscvInstruction "fmin\.s"
-syntax match   riscvInstruction "fmax\.s"
-syntax match   riscvInstruction "fcvt\.w\.s"
-syntax match   riscvInstruction "fcvt\.wu\.s"
-syntax match   riscvInstruction "fmv\.x\.w"
-syntax match   riscvInstruction "feq\.s"
-syntax match   riscvInstruction "flt\.s"
-syntax match   riscvInstruction "fle\.s"
-syntax match   riscvInstruction "fclass\.s"
-syntax match   riscvInstruction "fcvt\.s\.w"
-syntax match   riscvInstruction "fcvt\.s\.wu"
-syntax match   riscvInstruction "fmv\.w\.x"
-syntax match   riscvInstruction "fcvt\.l\.s"
-syntax match   riscvInstruction "fcvt\.lu\.s"
-syntax match   riscvInstruction "fcvt\.s\.l"
-syntax match   riscvInstruction "fcvt\.s\.lu"
+syntax match   riscvInstruction "\<fmadd\.s\>"
+syntax match   riscvInstruction "\<fmsub\.s\>"
+syntax match   riscvInstruction "\<fnmsub\.s\>"
+syntax match   riscvInstruction "\<fnmadd\.s\>"
+syntax match   riscvInstruction "\<fadd\.s\>"
+syntax match   riscvInstruction "\<fsub\.s\>"
+syntax match   riscvInstruction "\<fmul\.s\>"
+syntax match   riscvInstruction "\<fdiv\.s\>"
+syntax match   riscvInstruction "\<fsqrt\.s\>"
+syntax match   riscvInstruction "\<fsgnj\.s\>"
+syntax match   riscvInstruction "\<fsgnjn\.s\>"
+syntax match   riscvInstruction "\<fsgnjx\.s\>"
+syntax match   riscvInstruction "\<fmin\.s\>"
+syntax match   riscvInstruction "\<fmax\.s\>"
+syntax match   riscvInstruction "\<fcvt\.w\.s\>"
+syntax match   riscvInstruction "\<fcvt\.wu\.s\>"
+syntax match   riscvInstruction "\<fmv\.x\.w\>"
+syntax match   riscvInstruction "\<feq\.s\>"
+syntax match   riscvInstruction "\<flt\.s\>"
+syntax match   riscvInstruction "\<fle\.s\>"
+syntax match   riscvInstruction "\<fclass\.s\>"
+syntax match   riscvInstruction "\<fcvt\.s\.w\>"
+syntax match   riscvInstruction "\<fcvt\.s\.wu\>"
+syntax match   riscvInstruction "\<fmv\.w\.x\>"
+syntax match   riscvInstruction "\<fcvt\.l\.s\>"
+syntax match   riscvInstruction "\<fcvt\.lu\.s\>"
+syntax match   riscvInstruction "\<fcvt\.s\.l\>"
+syntax match   riscvInstruction "\<fcvt\.s\.lu\>"
 
 " D extension
 syntax keyword riscvInstruction fld fsd
-syntax match   riscvInstruction "fmadd\.d"
-syntax match   riscvInstruction "fmsub\.d"
-syntax match   riscvInstruction "fnmsub\.d"
-syntax match   riscvInstruction "fnmadd\.d"
-syntax match   riscvInstruction "fadd\.d"
-syntax match   riscvInstruction "fsub\.d"
-syntax match   riscvInstruction "fmul\.d"
-syntax match   riscvInstruction "fdiv\.d"
-syntax match   riscvInstruction "fsqrt\.d"
-syntax match   riscvInstruction "fsgnj\.d"
-syntax match   riscvInstruction "fsgnjn\.d"
-syntax match   riscvInstruction "fsgnjx\.d"
-syntax match   riscvInstruction "fmin\.d"
-syntax match   riscvInstruction "fmax\.d"
-syntax match   riscvInstruction "fcvt\.s\.d"
-syntax match   riscvInstruction "fcvt\.d\.s"
-syntax match   riscvInstruction "feq\.d"
-syntax match   riscvInstruction "flt\.d"
-syntax match   riscvInstruction "fle\.d"
-syntax match   riscvInstruction "fclass\.d"
-syntax match   riscvInstruction "fcvt\.w\.d"
-syntax match   riscvInstruction "fcvt\.wu\.d"
-syntax match   riscvInstruction "fcvt\.d\.w"
-syntax match   riscvInstruction "fcvt\.d\.wu"
-syntax match   riscvInstruction "fcvt\.l\.d"
-syntax match   riscvInstruction "fcvt\.lu\.d"
-syntax match   riscvInstruction "fmv\.x\.d"
-syntax match   riscvInstruction "fcvt\.d\.l"
-syntax match   riscvInstruction "fcvt\.d\.lu"
-syntax match   riscvInstruction "fmv\.d\.x"
+syntax match   riscvInstruction "\<fmadd\.d\>"
+syntax match   riscvInstruction "\<fmsub\.d\>"
+syntax match   riscvInstruction "\<fnmsub\.d\>"
+syntax match   riscvInstruction "\<fnmadd\.d\>"
+syntax match   riscvInstruction "\<fadd\.d\>"
+syntax match   riscvInstruction "\<fsub\.d\>"
+syntax match   riscvInstruction "\<fmul\.d\>"
+syntax match   riscvInstruction "\<fdiv\.d\>"
+syntax match   riscvInstruction "\<fsqrt\.d\>"
+syntax match   riscvInstruction "\<fsgnj\.d\>"
+syntax match   riscvInstruction "\<fsgnjn\.d\>"
+syntax match   riscvInstruction "\<fsgnjx\.d\>"
+syntax match   riscvInstruction "\<fmin\.d\>"
+syntax match   riscvInstruction "\<fmax\.d\>"
+syntax match   riscvInstruction "\<fcvt\.s\.d\>"
+syntax match   riscvInstruction "\<fcvt\.d\.s\>"
+syntax match   riscvInstruction "\<feq\.d\>"
+syntax match   riscvInstruction "\<flt\.d\>"
+syntax match   riscvInstruction "\<fle\.d\>"
+syntax match   riscvInstruction "\<fclass\.d\>"
+syntax match   riscvInstruction "\<fcvt\.w\.d\>"
+syntax match   riscvInstruction "\<fcvt\.wu\.d\>"
+syntax match   riscvInstruction "\<fcvt\.d\.w\>"
+syntax match   riscvInstruction "\<fcvt\.d\.wu\>"
+syntax match   riscvInstruction "\<fcvt\.l\.d\>"
+syntax match   riscvInstruction "\<fcvt\.lu\.d\>"
+syntax match   riscvInstruction "\<fmv\.x\.d\>"
+syntax match   riscvInstruction "\<fcvt\.d\.l\>"
+syntax match   riscvInstruction "\<fcvt\.d\.lu\>"
+syntax match   riscvInstruction "\<fmv\.d\.x\>"
 
 " Q extension
 syntax keyword riscvInstruction flq fsq
-syntax match   riscvInstruction "fmadd\.q"
-syntax match   riscvInstruction "fmsub\.q"
-syntax match   riscvInstruction "fnmsub\.q"
-syntax match   riscvInstruction "fnmadd\.q"
-syntax match   riscvInstruction "fadd\.q"
-syntax match   riscvInstruction "fsub\.q"
-syntax match   riscvInstruction "fmul\.q"
-syntax match   riscvInstruction "fdiv\.q"
-syntax match   riscvInstruction "fsqrt\.q"
-syntax match   riscvInstruction "fsgnj\.q"
-syntax match   riscvInstruction "fsgnjn\.q"
-syntax match   riscvInstruction "fsgnjx\.q"
-syntax match   riscvInstruction "fmin\.q"
-syntax match   riscvInstruction "fmax\.q"
-syntax match   riscvInstruction "fcvt\.s\.q"
-syntax match   riscvInstruction "fcvt\.q\.s"
-syntax match   riscvInstruction "fcvt\.d\.q"
-syntax match   riscvInstruction "fcvt\.q\.d"
-syntax match   riscvInstruction "feq\.q"
-syntax match   riscvInstruction "flt\.q"
-syntax match   riscvInstruction "fle\.q"
-syntax match   riscvInstruction "fclass\.d"
-syntax match   riscvInstruction "fcvt\.w\.q"
-syntax match   riscvInstruction "fcvt\.wu\.q"
-syntax match   riscvInstruction "fcvt\.q\.w"
-syntax match   riscvInstruction "fcvt\.q\.wu"
-syntax match   riscvInstruction "fcvt\.l\.q"
-syntax match   riscvInstruction "fcvt\.lu\.q"
-syntax match   riscvInstruction "fcvt\.q\.l"
-syntax match   riscvInstruction "fcvt\.q\.lu"
+syntax match   riscvInstruction "\<fmadd\.q\>"
+syntax match   riscvInstruction "\<fmsub\.q\>"
+syntax match   riscvInstruction "\<fnmsub\.q\>"
+syntax match   riscvInstruction "\<fnmadd\.q\>"
+syntax match   riscvInstruction "\<fadd\.q\>"
+syntax match   riscvInstruction "\<fsub\.q\>"
+syntax match   riscvInstruction "\<fmul\.q\>"
+syntax match   riscvInstruction "\<fdiv\.q\>"
+syntax match   riscvInstruction "\<fsqrt\.q\>"
+syntax match   riscvInstruction "\<fsgnj\.q\>"
+syntax match   riscvInstruction "\<fsgnjn\.q\>"
+syntax match   riscvInstruction "\<fsgnjx\.q\>"
+syntax match   riscvInstruction "\<fmin\.q\>"
+syntax match   riscvInstruction "\<fmax\.q\>"
+syntax match   riscvInstruction "\<fcvt\.s\.q\>"
+syntax match   riscvInstruction "\<fcvt\.q\.s\>"
+syntax match   riscvInstruction "\<fcvt\.d\.q\>"
+syntax match   riscvInstruction "\<fcvt\.q\.d\>"
+syntax match   riscvInstruction "\<feq\.q\>"
+syntax match   riscvInstruction "\<flt\.q\>"
+syntax match   riscvInstruction "\<fle\.q\>"
+syntax match   riscvInstruction "\<fclass\.d\>"
+syntax match   riscvInstruction "\<fcvt\.w\.q\>"
+syntax match   riscvInstruction "\<fcvt\.wu\.q\>"
+syntax match   riscvInstruction "\<fcvt\.q\.w\>"
+syntax match   riscvInstruction "\<fcvt\.q\.wu\>"
+syntax match   riscvInstruction "\<fcvt\.l\.q\>"
+syntax match   riscvInstruction "\<fcvt\.lu\.q\>"
+syntax match   riscvInstruction "\<fcvt\.q\.l\>"
+syntax match   riscvInstruction "\<fcvt\.q\.lu\>"
+
+" float rouding modes
+syntax keyword riscvDirective rne rtz rdn rup rmm dyn
 
 " RV64I
 " load and store
@@ -315,12 +321,24 @@ syntax keyword riscvInstruction addw subw addiw
 syntax keyword riscvInstruction mulw divw divuw remw remuw
 
 " pseudo-instructions
-syntax keyword riscvInstruction nop li la mv
+syntax keyword riscvInstruction nop li la lla mv
 syntax keyword riscvInstruction not neg negw
-syntax match   riscvInstruction "sext\.w"
+syntax match   riscvInstruction "\<sext\.w\>"
 syntax keyword riscvInstruction seqz snez sltz sgtz
 syntax keyword riscvInstruction beqz bnez blez bgtz bgt ble bgtu bleu bgez bltz
-syntax keyword riscvInstruction j jr ret call
+syntax keyword riscvInstruction j jr ret call tail jump
+
+" relocations
+syntax match   riscvDirective "\<%hi\>"
+syntax match   riscvDirective "\<%lo\>"
+syntax match   riscvDirective "\<%pcrel_hi\>"
+syntax match   riscvDirective "\<%pcrel_lo\>"
+syntax match   riscvDirective "\<%tprel_hi\>"
+syntax match   riscvDirective "\<%tprel_lo\>"
+syntax match   riscvDirective "\<%tprel_add\>"
+syntax match   riscvDirective "\<%tls_ie_pcrel_hi\>"
+syntax match   riscvDirective "\<%tls_gd_pcrel_hi\>"
+syntax match   riscvDirective "\<%got_pcrel_hi\>"
 
 hi def link riscvComment        Comment
 hi def link riscvTodo           Todo

--- a/syntax/riscv.vim
+++ b/syntax/riscv.vim
@@ -5,7 +5,7 @@ if exists("b:current_syntax")
     syntax clear
 endif
 
-setlocal iskeyword+=-,$
+setlocal iskeyword+=-,$,.
 syntax case match
 
 syntax match   riscvComment    /#.*/


### PR DESCRIPTION
Hello Kyle,
a set of commits to (a) add '.' as "normal" character so that '*' will work as expected, (b) generalized the use of \< and \> in a match so that only exact words are matches (i.e. c.addzz was partly seen as an instruction before, because c.add was matching), and (c) added a few more keywords in pseudo-ops, rounding modes, and relocations.