### PR TITLE
Add subi pseudo-instruction

### DIFF
--- a/syntax/riscv.vim
+++ b/syntax/riscv.vim
@@ -358,6 +358,7 @@ syntax match   riscvInstruction /\<vmv[1248]r\.v\>/
 
 " pseudo-instructions
 syntax keyword riscvInstruction li la lla lga
+syntax keyword riscvInstruction subi
 syntax keyword riscvInstruction nop mv
 syntax keyword riscvInstruction not neg negw
 syntax keyword riscvInstruction sext.b sext.h sext.w zext.b zext.h zext.w


### PR DESCRIPTION
I recently came across a flavour of RISC-V that had `subi` as a pseudo-instruction and it wasn't recognised by this plugin, so This PR adds it to the list of recognised instructions.