### PR TITLE
Better label identification

### DIFF
--- a/syntax/riscv.vim
+++ b/syntax/riscv.vim
@@ -24,7 +24,7 @@ syntax match   riscvLabelColon /:/ contained
 syntax match   riscvLabel      /^\s*\.\?\h\w*:/ contains=riscvLabelColon
 syntax match   riscvLabel      /^\s*\d\+:/ contains=riscvLabelColon
 " A reference to a local label using <num>[BF]
-syntax match   riscvLabelRef   /\d\+[bf]/
+syntax match   riscvLabelRef   /\<\d\+[bf]\>/
 
 " Registers
 " Numbered registers

--- a/syntax/riscv.vim
+++ b/syntax/riscv.vim
@@ -21,7 +21,8 @@ syntax match   riscvNumber     /\<-\?0\(x\|X\)[0-9a-fA-F]\+\>/
 syntax region  riscvString     start=/"/ skip=/\\"/ end=/"/
 syntax region  riscvChar       start=/'/ skip=/\\'/ end=/'/
 syntax match   riscvLabelColon /:/ contained
-syntax match   riscvLabel      /\w\+:/ contains=riscvLabelColon
+syntax match   riscvLabel      /^\s*\.\?\h\w*:/ contains=riscvLabelColon
+syntax match   riscvLabel      /^\s*\d\+:/ contains=riscvLabelColon
 " A reference to a local label using <num>[BF]
 syntax match   riscvLabelRef   /\d\+[bf]/
 

--- a/syntax/riscv.vim
+++ b/syntax/riscv.vim
@@ -107,6 +107,9 @@ syntax keyword riscvDirective .4byte .word .long .8byte .dword .quad .skip
 syntax keyword riscvDirective .dtprelword .dtpreldword .sleb128 .uleb128
 syntax keyword riscvDirective .p2align .balign
 syntax keyword riscvDirective .global .float .double .set .attribute
+syntax keyword riscvDirective .cfi_sections .cfi_startproc .cfi_endproc .cfi_def_cfa
+syntax keyword riscvDirective .cfi_offset .cfi_def_cfa_offset .cfi_restore
+syntax keyword riscvDirective .octa .debug_frame .loc .weak
 
 " RV32I
 " Integer Register-Immediate Instructions


### PR DESCRIPTION
Labels can start with a dot (local ones) but cannot start with a digit unless the whole label is a number.
They also should be at the start of the line (with possibly spaces ahead).